### PR TITLE
Return data as a tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ URL: https://github.com/r-hub/cranlogs, https://r-hub.github.io/cranlogs
 BugReports: https://github.com/r-hub/cranlogs/issues
 Imports:
     httr,
-    jsonlite
+    jsonlite,
+    tibble
 Encoding: UTF-8
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Suggests: 
     testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 
 # dev
+* Return a `tibble::tibble()` rather than a `data.frame`
 
 # cranlogs 2.1.1
 

--- a/man/cran_downloads.Rd
+++ b/man/cran_downloads.Rd
@@ -4,8 +4,12 @@
 \alias{cran_downloads}
 \title{Daily package downloads from the RStudio CRAN mirror}
 \usage{
-cran_downloads(packages = NULL, when = c("last-day", "last-week",
-  "last-month"), from = "last-day", to = "last-day")
+cran_downloads(
+  packages = NULL,
+  when = c("last-day", "last-week", "last-month"),
+  from = "last-day",
+  to = "last-day"
+)
 }
 \arguments{
 \item{packages}{A character vector, the packages to query,
@@ -23,7 +27,7 @@ details). If this is given, then \code{from} and \code{to} are ignored.}
 \code{last-day}. It is ignored if \code{when} is given.}
 }
 \value{
-For packages a data frame with columns:
+For packages a tibble with columns:
   \item{\code{package}}{The package. This column is missing if
     all packages were queried.}
   \item{\code{date}}{Day of the downloads, it is a Date object.}
@@ -66,6 +70,7 @@ cran_downloads("R")
 }
 }
 \seealso{
-Other CRAN downloads: \code{\link{cran_top_downloads}}
+Other CRAN downloads: 
+\code{\link{cran_top_downloads}()}
 }
 \concept{CRAN downloads}

--- a/man/cran_top_downloads.Rd
+++ b/man/cran_top_downloads.Rd
@@ -4,8 +4,7 @@
 \alias{cran_top_downloads}
 \title{Top downloaded packages from the RStudio CRAN mirror}
 \usage{
-cran_top_downloads(when = c("last-day", "last-week", "last-month"),
-  count = 10)
+cran_top_downloads(when = c("last-day", "last-week", "last-month"), count = 10)
 }
 \arguments{
 \item{when}{\code{last-day}, \code{last-week} or \code{last-month} (see 
@@ -16,7 +15,7 @@ lists only at most 100 packages. This number might change in the
 future.}
 }
 \value{
-A data frame with columns: \code{rank}, \code{package},
+A tibble with columns: \code{rank}, \code{package},
   \code{count}, \code{from}, \code{to}.
 }
 \description{
@@ -42,6 +41,7 @@ cran_top_downloads(when = "last-week")
 
 }
 \seealso{
-Other CRAN downloads: \code{\link{cran_downloads}}
+Other CRAN downloads: 
+\code{\link{cran_downloads}()}
 }
 \concept{CRAN downloads}

--- a/man/cranlogs-package.Rd
+++ b/man/cranlogs-package.Rd
@@ -6,6 +6,8 @@
 \alias{cranlogs-package}
 \title{cranlogs: Download Logs from the 'RStudio' 'CRAN' Mirror}
 \description{
+\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+
 'API' to the database of 'CRAN' package downloads from the
     'RStudio' 'CRAN mirror'. The database itself is at <http://cranlogs.r-pkg.org>,
     see <https://github.com/r-hub/cranlogs.app> for the raw 'API'.

--- a/man/cranlogs_badge.Rd
+++ b/man/cranlogs_badge.Rd
@@ -4,8 +4,11 @@
 \alias{cranlogs_badge}
 \title{Create Markdown code for a cranlogs badge}
 \usage{
-cranlogs_badge(package_name, summary = c("last-month", "last-day",
-  "last-week", "grand-total"), color = "blue")
+cranlogs_badge(
+  package_name,
+  summary = c("last-month", "last-day", "last-week", "grand-total"),
+  color = "blue"
+)
 }
 \arguments{
 \item{package_name}{name of the package}


### PR DESCRIPTION
This is a bit of a stylistic preference but my understanding is that tibbles are now preferred to data.frames.

This PR:
* Adds tibble as a dependency
* Uses tibble::tibble for returned data
* Renames {to_df*} functions to {to_tibble*}
* Supplementary updates to documentation from runing `devtools::document()`

No dramas if you prefer data frames though