### PR TITLE
Add Rdata and Rhistory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .Rproj.user
 docs
 /revdep
+.Rdata
+.Rhistory


### PR DESCRIPTION
When developing #59 git wanted to send up my `.Rdata` and `.Rhistory` files, so this just adds those to `.gitignore`