### PR TITLE
added use_cranlogs_badge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,10 @@ Imports:
     httr,
     jsonlite
 Encoding: UTF-8
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Suggests: 
-    testthat
+    testthat,
+    usethis,
+    rprojroot,
+    fs,
+    desc

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(cran_downloads)
 export(cran_top_downloads)
 export(cranlogs_badge)
+export(use_cranlogs_badge)
 importFrom(httr,GET)
 importFrom(httr,content)
 importFrom(httr,stop_for_status)

--- a/R/badge.R
+++ b/R/badge.R
@@ -31,3 +31,57 @@ cranlogs_badge <- function(package_name,
          badge_url, ")](", pkg_url, ")")
   
 }
+
+project_name = function(base_path = usethis::proj_get()) {
+  # taken from usethis
+  proj_crit = function ()  {
+    rprojroot::has_file(".here") | 
+      rprojroot::is_rstudio_project | 
+      rprojroot::is_r_package | 
+      rprojroot::is_git_root | 
+      rprojroot::is_remake_project | 
+      rprojroot::is_projectile_project
+  }
+  
+  proj_find = function(path = ".") {
+    tryCatch(rprojroot::find_root(proj_crit(), path = path), 
+             error = function(e) NULL)
+  }
+  possibly_in_proj = function (path = ".") !is.null(proj_find(path))
+  if (!possibly_in_proj(base_path)) {
+    return(fs::path_file(base_path))
+  }
+  
+  is_package = function (base_path = usethis::proj_get()) 
+  {
+    res <- tryCatch(rprojroot::find_package_root_file(path = base_path), 
+                    error = function(e) NULL)
+    !is.null(res)
+  }
+  if (is_package(base_path)) {
+    desc <- desc::description$new(base_path)
+    as.list(desc$get(desc$fields()))$Package
+  }
+  else {
+    fs::path_file(base_path)
+  }
+}
+
+#' @rdname cranlogs_badge
+#' @export
+use_cranlogs_badge = function(
+  summary = c("last-month", "last-day", 
+              "last-week", "grand-total"),
+  color = "blue") {
+  if ( !(requireNamespace("fs", quietly = TRUE) &&
+         requireNamespace("usethis", quietly = TRUE) &&
+         requireNamespace("desc", quietly = TRUE) &&
+         requireNamespace("rprojroot", quietly = TRUE)) ) {
+    stop("Cannot use use_cranlogs_badge without fs, usethis, ", 
+         "desc, and rprojroot packages")
+  }
+  package_name = project_name()
+  cranlogs_badge(package_name, 
+                 summary = summary, 
+                 color = color)
+}

--- a/R/badge.R
+++ b/R/badge.R
@@ -73,6 +73,7 @@ use_cranlogs_badge = function(
   summary = c("last-month", "last-day", 
               "last-week", "grand-total"),
   color = "blue") {
+  summary <- match.arg(summary)
   if ( !(requireNamespace("fs", quietly = TRUE) &&
          requireNamespace("usethis", quietly = TRUE) &&
          requireNamespace("desc", quietly = TRUE) &&
@@ -81,7 +82,13 @@ use_cranlogs_badge = function(
          "desc, and rprojroot packages")
   }
   package_name = project_name()
-  cranlogs_badge(package_name, 
-                 summary = summary, 
-                 color = color)
+  
+  pkg_url <- paste0("https://r-pkg.org/pkg/", package_name)
+  
+  badge_url <- paste0("https://cranlogs.r-pkg.org/badges/",
+                      summary, "/",
+                      package_name, 
+                      "?color=", color)
+
+  usethis::use_badge("CRAN RStudio mirror downloads", pkg_url, badge_url)
 }

--- a/man/cran_downloads.Rd
+++ b/man/cran_downloads.Rd
@@ -4,8 +4,12 @@
 \alias{cran_downloads}
 \title{Daily package downloads from the RStudio CRAN mirror}
 \usage{
-cran_downloads(packages = NULL, when = c("last-day", "last-week",
-  "last-month"), from = "last-day", to = "last-day")
+cran_downloads(
+  packages = NULL,
+  when = c("last-day", "last-week", "last-month"),
+  from = "last-day",
+  to = "last-day"
+)
 }
 \arguments{
 \item{packages}{A character vector, the packages to query,
@@ -66,6 +70,7 @@ cran_downloads("R")
 }
 }
 \seealso{
-Other CRAN downloads: \code{\link{cran_top_downloads}}
+Other CRAN downloads: 
+\code{\link{cran_top_downloads}()}
 }
 \concept{CRAN downloads}

--- a/man/cran_top_downloads.Rd
+++ b/man/cran_top_downloads.Rd
@@ -4,8 +4,7 @@
 \alias{cran_top_downloads}
 \title{Top downloaded packages from the RStudio CRAN mirror}
 \usage{
-cran_top_downloads(when = c("last-day", "last-week", "last-month"),
-  count = 10)
+cran_top_downloads(when = c("last-day", "last-week", "last-month"), count = 10)
 }
 \arguments{
 \item{when}{\code{last-day}, \code{last-week} or \code{last-month} (see 
@@ -42,6 +41,7 @@ cran_top_downloads(when = "last-week")
 
 }
 \seealso{
-Other CRAN downloads: \code{\link{cran_downloads}}
+Other CRAN downloads: 
+\code{\link{cran_downloads}()}
 }
 \concept{CRAN downloads}

--- a/man/cranlogs-package.Rd
+++ b/man/cranlogs-package.Rd
@@ -6,6 +6,8 @@
 \alias{cranlogs-package}
 \title{cranlogs: Download Logs from the 'RStudio' 'CRAN' Mirror}
 \description{
+\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+
 'API' to the database of 'CRAN' package downloads from the
     'RStudio' 'CRAN mirror'. The database itself is at <http://cranlogs.r-pkg.org>,
     see <https://github.com/r-hub/cranlogs.app> for the raw 'API'.

--- a/man/cranlogs_badge.Rd
+++ b/man/cranlogs_badge.Rd
@@ -2,10 +2,19 @@
 % Please edit documentation in R/badge.R
 \name{cranlogs_badge}
 \alias{cranlogs_badge}
+\alias{use_cranlogs_badge}
 \title{Create Markdown code for a cranlogs badge}
 \usage{
-cranlogs_badge(package_name, summary = c("last-month", "last-day",
-  "last-week", "grand-total"), color = "blue")
+cranlogs_badge(
+  package_name,
+  summary = c("last-month", "last-day", "last-week", "grand-total"),
+  color = "blue"
+)
+
+use_cranlogs_badge(
+  summary = c("last-month", "last-day", "last-week", "grand-total"),
+  color = "blue"
+)
 }
 \arguments{
 \item{package_name}{name of the package}


### PR DESCRIPTION
Added `use_cranlogs_badge`.  I harvested `project_name` from `usethis` (couldn't find an exposed function), which adds a heavy load of deps: `desc`, `fs`, `rprojroot`, and `usethis`.  Added to suggests so that they are not hard deps.  So take it or leave it - may not be enough to warrant the dependencies.